### PR TITLE
[ELITERT-1198] Add action to generate the Sphinx doc

### DIFF
--- a/.github/workflows/sphinx-doc.yml
+++ b/.github/workflows/sphinx-doc.yml
@@ -1,0 +1,67 @@
+# This workflow will generate the Sphinx documentation
+
+name: Sphinx Documentation
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+      # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: 2.7.7
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Generate YARD documentation
+      run: |
+        bundler exec yard doc . --exclude vendor/ -o documentation/build/html/yard
+    - name: Install pandoc
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install pandoc
+    - name: Convert README
+      run: |
+        pandoc CHANGELOG.md --from markdown --to rst -s -o documentation/source/introduction/changelog.rst
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      working-directory: ./documentation
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Generate Documentation
+      working-directory: ./documentation
+      run: |
+        make html
+    - name: Upload static files as artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: documentation/build/html/
+
+  deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This action is equivalent to the documentation Jenkins job the project used to have. It does the following:

 * Generates the YARD documentation
 * Converts the `CHANGELOG.md` to Sphinx.
 * Generates the Sphinx documentation.
 * Uploads the artifact
 * Deploys the artifact to Github pages.

It only does this once changes are merged to master, just like the Jenkins job did.