### PR TITLE
[ELITERT-1198] Add action to run Ruby linters

### DIFF
--- a/.github/workflows/ruby-linters.yml
+++ b/.github/workflows/ruby-linters.yml
@@ -1,0 +1,41 @@
+# This workflow runs Rubocop on the Pull Requests to make sure no linter warnings slip by.
+
+name: Ruby Linters
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_ONLY: linting
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+    - name: Install Gems
+      run: |
+        bundler install
+    - name: Run Rubocop
+      continue-on-error: true
+      uses: reviewdog/action-rubocop@v2.19.1
+      with:
+        skip_install: true
+        rubocop_version: gemfile
+        rubocop_extensions: rubocop-rspec:gemfile
+        use_bundler: true
+    - name: reek
+      continue-on-error: true
+      uses: reviewdog/action-reek@v1
+      with:
+        reek_version: gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   Exclude:
+    - vendor/**/*
     - spec/spec_helper.rb
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,12 @@ gemspec
 
 gem 'pry', '~>0'
 gem 'rake', '~> 12.0'
-gem 'reek', '~> 6'
 gem 'rspec', '~> 3.0'
-gem 'rubocop', '~> 1'
-gem 'rubocop-rspec', '2'
 gem 'simplecov', '~> 0.17.0'
 gem 'yard', '~> 0'
+
+group :linting do
+  gem 'reek', '~> 6'
+  gem 'rubocop', '~> 1'
+  gem 'rubocop-rspec', '~> 3'
+end


### PR DESCRIPTION
The action runs Rubocop and Reek on Pull Requests.

* The action doesn't fail when there are linter warnings it only adds comments to the files in the Pull Request.

* To reduce the time needed to install gems the gems needed for linting are being moved to a group and the `BUNDLE_ONLY` environment variable is being used to install only those.

* To prevent Rubocop from scanning the `vendor` directory an exclusion entry is being added to its configuration file.