### PR TITLE
[ELITERT-1198] Generate reports alongside documentation

### DIFF
--- a/.github/workflows/sphinx-doc.yml
+++ b/.github/workflows/sphinx-doc.yml
@@ -14,6 +14,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      COVERAGE: true
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
@@ -24,6 +27,15 @@ jobs:
       with:
         ruby-version: 2.7.7
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Test Results and Coverage
+      run:
+        bundler exec rspec --format html -o documentation/build/html/test_results/index.html
+    - name: Move Coverage Report
+      run:
+        mv coverage documentation/build/html/coverage
+    - name: Static Analysis Report
+      run:
+        bundler exec rubocop . --format html -o documentation/build/html/static_code_analysis/index.html || true
     - name: Generate YARD documentation
       run: |
         bundler exec yard doc . --exclude vendor/ -o documentation/build/html/yard

--- a/documentation/source/appendix/links_and_resources.rst
+++ b/documentation/source/appendix/links_and_resources.rst
@@ -25,17 +25,17 @@ Build Infrastructure
 Test Results
 ------------
 
-* `Tests Results <https://jenkins.int.esrlabs.com/job/Testing-Tools/job/dragnet/job/dragnet-verifier/Test_20Results/>`_
+* `Tests Results <../test_results/index.html>`_
 
 Static Code Analysis
 --------------------
 
-* `Rubocop Report <https://jenkins.int.esrlabs.com/job/Testing-Tools/job/dragnet/job/dragnet-verifier/Rubocop_20Report/>`_
+* `Rubocop Report <../static_code_analysis/index.html>`_
 
 Code Coverage
 -------------
 
-* `Code Coverage Report <https://jenkins.int.esrlabs.com/job/Testing-Tools/job/dragnet/job/dragnet-verifier/Coverage_20Report/>`_
+* `Code Coverage Report <../coverage/index.html>`_
 
 Requirements Coverage
 ---------------------


### PR DESCRIPTION
* Changes the documentation generation action to include the generation of the following reports:

 - Test Results Report (generated by RSpec)
 - Code Coverage (generated by SimpleCOV)
 - Static Code Analysis (generated by Rubocop)

* Changes the links in the "Links and Resources" page of the documentation to make them point to the generated assets instead of the internal Jenkins locations.