### PR TITLE
[ELITERT-1198] Set-up rubygems.org deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release and Deploy
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - lib/dragnet/version.rb
+
+jobs:
+  build:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create the tag and the release
+      id-token: write # Needed to push to rubygems.org as a trusted publisher
+    environment: release
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: 2.7.7
+    - name: Build
+      run: |
+        bundler install
+        rake clobber
+        rake build
+    - name: Get Version
+      run: |
+        echo "GEM_VERSION=$(bundler exec ruby -e 'require "dragnet/version"; print Dragnet::VERSION')" | tee -a $GITHUB_ENV
+    - name: Create Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Github Actions
+        TAG_NAME: ${{ env.GEM_VERSION }}
+        NOTES: "[Changelog](${{ github.server_url }}/${{ github.repository }}/blob/${{ env.GEM_VERSION }}/CHANGELOG.md)"
+        TITLE: Release ${{ env.GEM_VERSION }}
+        TARGET: ${{ github.ref_name }}
+      run: |
+        gh release create $TAG_NAME --notes "$NOTES" --title "$TITLE" --target $TARGET pkg/dragnet-*.gem
+    - name: Configure trusted publishing credentials
+      uses: rubygems/configure-rubygems-credentials@v1.0.0
+    - name: Deploy
+      run: |
+        gem push pkg/dragnet-*.gem

--- a/dragnet.gemspec
+++ b/dragnet.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
-  spec.metadata['allowed_push_host'] = 'https://gems.int.esrlabs.com'
+  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
Performs the following actions to allow the gem to be deployed to rubygems.org on release:

* Changes the `.gemspec` file to allow the gem to be pushed to rubygems.org
* Adds a Github action to build the gem, create a release and deploy the gem to rubygems.org when release pull requests are merged.

NOTE: Because this actions creates releases and pushes things to rubygems.org I could not test this on this repository. Instead I [created a personal repository](https://github.com/sergio-bobillier/sb-test) and [tested it there](https://github.com/sergio-bobillier/sb-test/actions).