### PR TITLE
[ELITERT-1198] Remove internal gemserver URL

### DIFF
--- a/documentation/source/user_guidelines/introduction.rst
+++ b/documentation/source/user_guidelines/introduction.rst
@@ -29,7 +29,7 @@ you can use the CLI to execute the tool.
 
 To install dragnet tool::
 
-  gem install -s https://gems.int.esrlabs.com dragnet
+  gem install dragnet
 
 Needed configuration
 --------------------


### PR DESCRIPTION
Since the gem is now available on rubygems.org the URL of the internal gemserver is no longer required for installation, hence it is being removed from the documentation.