### PR TITLE
[ELITERT-1212] Add Ruby 3.x to the RSpec verifier

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7']
+        ruby-version: ['2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The idea is to make sure that the gem works properly in both Ruby 2.x and 3.x before completely dropping the support for Ruby 2.x.