### PR TITLE
[ELITERT-1221] Render MTRs' descriptions as Markdown in the generated HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Changed
+- The `description` field will now be rendered as Markdown in the HTML report.
+
 ## [5.2.1] - 2024-11-13
 
 ### Fixed

--- a/lib/dragnet/exporters/templates/template.html.erb
+++ b/lib/dragnet/exporters/templates/template.html.erb
@@ -3,6 +3,7 @@
         <meta charset="UTF-8" />
         <title>Dragnet Report for <%= repository.multi? ? "Multiple Repositories" : shorten_sha1(repository.head.sha) %></title>
         <script src="https://unpkg.com/@tabler/core@1.0.0-beta2/dist/js/tabler.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@tabler/core@1.0.0-beta2/dist/css/tabler.min.css">
     </head>
     <body class="antialiased"> <!-- theme-dark -->
@@ -468,8 +469,8 @@
                                                     <dt class="col-3">SECL:</dt>
                                                     <dd class="col-9"> -- Not implemented -- </dd>
                                                     <dt class="col-3">Description:</dt>
-                                                    <dd class="col-9">
-                                                      <%= test_record.description %>
+                                                    <dd class="col-9 md-description">
+                                                      <%= test_record.description&.gsub("\n", '<br />') %>
                                                     </dd>
                                                     <dt class="col-3">Test Result:</dt>
                                                     <dd class="col-9"><%= verification_result_badge(test_record.verification_result) %></dd>
@@ -514,5 +515,13 @@
                 </footer>
             </div>
         </div>
+        <script type="text/javascript">
+          elements = document.getElementsByClassName('md-description')
+
+          for(let element of elements) {
+              const source = element.innerText
+              element.innerHTML = marked.parse(source)
+          }
+        </script>
     </body>
 </html>

--- a/req/exporter.dim
+++ b/req/exporter.dim
@@ -7,6 +7,7 @@ SRS_DRAGNET_0022:
   tags:            covered, tested
   test_setups:     off_target
   status:          valid
+  refs:            SRS_DRAGNET_0079
 
 SRS_DRAGNET_0023:
   text:            |
@@ -142,5 +143,21 @@ SRS_DRAGNET_0067:
                    Only the first 16 characters of the resulting SHA1 shall be
                    used.
   tags:            covered, tested
+  test_setups:     off_target
+  status:          valid
+
+SRS_DRAGNET_0079:
+  text:            |
+                   The MTR's 'description' field shall be rendered as Markdown
+                   in the exported HTML.
+  test_setups:     off_target
+  status:          valid
+  refs:            SRS_DRAGNET_0080
+
+SRS_DRAGNET_0080:
+  text:            |
+                   The 'description' text shall be sanitized **BEFORE**
+                   rendering it as Markdown to prevent XSS in the generated HTML
+                   report.
   test_setups:     off_target
   status:          valid

--- a/req/exporter.dim
+++ b/req/exporter.dim
@@ -151,6 +151,7 @@ SRS_DRAGNET_0079:
                    The MTR's 'description' field shall be rendered as Markdown
                    in the exported HTML.
   test_setups:     off_target
+  tags:            covered, tested
   status:          valid
   refs:            SRS_DRAGNET_0080
 
@@ -159,5 +160,6 @@ SRS_DRAGNET_0080:
                    The 'description' text shall be sanitized **BEFORE**
                    rendering it as Markdown to prevent XSS in the generated HTML
                    report.
+  tags:            covered, tested
   test_setups:     off_target
   status:          valid


### PR DESCRIPTION
This pull request adds the necessary code to allow the MTRs' descriptions to be rendered as Markdown in the generated HTML report. This enhances the readability of the text, even in simple MTRs and it allows more advanced formatting, like bullets, code blocks or even links to be added to the MTRs.

Here is a showcase of what this change does:

### Before

![Screenshot 2024-11-28 at 14 55 19](https://github.com/user-attachments/assets/ff4de175-f23f-44f4-af81-66e53ae25e04)

### After

![Screenshot 2024-11-28 at 14 54 44](https://github.com/user-attachments/assets/3779cf50-cbe9-4651-a56e-b4c176bd6040)
