### PR TITLE
Fix links to dim's documentation

### DIFF
--- a/documentation/source/appendix/glossary.rst
+++ b/documentation/source/appendix/glossary.rst
@@ -53,6 +53,6 @@ Exporting
   Here Dragnet exports the results of the above steps to the specified format.
   The exported data varies with the selected format.
 
-.. _DIM: https://docs.int.esrlabs.com/dim/index.html
+.. _DIM: https://esrlabs.github.io/dox/dim/
 .. _Git: https://git-scm.com/
 .. _commit: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_committing_changes

--- a/documentation/source/introduction/contributing.rst
+++ b/documentation/source/introduction/contributing.rst
@@ -77,7 +77,7 @@ new version of the gem. To do so:
 
 .. _`Dragnet's Issue Tracker`: https://github.com/esrlabs/dragnet/issues
 .. _`Dragnet's Repository`: https://github.com/esrlabs/dragnet
-.. _DIM: https://docs.int.esrlabs.com/dim/index.html
+.. _DIM: https://esrlabs.github.io/dox/dim/
 .. _`Test documentation`: https://docs.int.esrlabs.com/guidelines/general/testing/test_documentation.html
 .. _`Keep a Changelog`: https://keepachangelog.com/en/1.0.0/
 .. _`ESR Labs's guidelines for writing commit messages`: https://docs.int.esrlabs.com/guidelines/general/scm/commit_message.html

--- a/documentation/source/requirements/index.rst
+++ b/documentation/source/requirements/index.rst
@@ -13,4 +13,4 @@ generated yet. To generate the requirements run the following command:
 
 And then generate the Sphinx documentation again.
 
-.. _DIM: https://docs.int.esrlabs.com/dim/index.html
+.. _DIM: https://esrlabs.github.io/dox/dim/


### PR DESCRIPTION
dim's documentation is now on Github. This commit fixes the links so that they point to the new URL, which, unlike the old one, is accessible to anyone.