### PR TITLE
[ELITERT-1043] Add the MTRs' file names to the JSON export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- The JSON export now includes the path to the MTR files.
+
 ### Changed
 - The `description` field will now be rendered as Markdown in the HTML report.
 

--- a/lib/dragnet/exporters/serializers/test_record_serializer.rb
+++ b/lib/dragnet/exporters/serializers/test_record_serializer.rb
@@ -37,6 +37,7 @@ module Dragnet
             refs: Array(test_record.id),
             result: test_record.result,
             review_status: render_review_status,
+            mtr_file: relative_to_repo(test_record.source_file).to_s,
             verification_result: serialized_verification_result,
 
             # TODO: Remove the started_at and finished_at attributes after solving

--- a/req/exporter.dim
+++ b/req/exporter.dim
@@ -41,7 +41,8 @@ SRS_DRAGNET_0060:
   test_setups:     off_target
   tags:            covered, tested
   status:          valid
-  refs:            SRS_DRAGNET_0061, SRS_DRAGNET_0062, SRS_DRAGNET_0063, SRS_DRAGNET_0064, SRS_DRAGNET_0065
+  refs:            SRS_DRAGNET_0061, SRS_DRAGNET_0062, SRS_DRAGNET_0063, SRS_DRAGNET_0064, SRS_DRAGNET_0065,
+                   SRS_DRAGNET_0081
 
 SRS_DRAGNET_0061:
   text:            |
@@ -161,5 +162,9 @@ SRS_DRAGNET_0080:
                    rendering it as Markdown to prevent XSS in the generated HTML
                    report.
   tags:            covered, tested
+
+SRS_DRAGNET_0081:
+  text:            |
+                   The JSON exporter shall export the MTR's filename.
   test_setups:     off_target
   status:          valid

--- a/req/exporter.dim
+++ b/req/exporter.dim
@@ -166,5 +166,6 @@ SRS_DRAGNET_0080:
 SRS_DRAGNET_0081:
   text:            |
                    The JSON exporter shall export the MTR's filename.
+  tags:            covered, tested
   test_setups:     off_target
   status:          valid

--- a/spec/dragnet/exporters/serializers/test_record_serializer_spec.rb
+++ b/spec/dragnet/exporters/serializers/test_record_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
   let(:review_comments) { nil }
   let(:has_findings) { false }
   let(:findings) { nil }
+  let(:source_file) { Pathname.new('/workspace/path/to/repo/manual/ESR_REQ_7630.yaml') }
   let(:files) { nil }
   let(:repos) { nil }
 
@@ -40,6 +41,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
       findings?: has_findings,
       findings: findings,
       verification_result: verification_result,
+      source_file: source_file,
       files: files,
       repos: repos
     )
@@ -274,6 +276,11 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
       it 'includes the findings' do
         expect(method_call).to include(findings: findings)
       end
+    end
+
+    it "includes the TestRecord's source file (relative to the Repository's root)",
+       requirements: %w[SRS_DRAGNET_0081] do
+      expect(method_call).to include(mtr_file: 'manual/ESR_REQ_7630.yaml')
     end
 
     it "includes the TestRecord's serialized VerificationResult" do

--- a/spec/integration/dragnet/exporters/json_exporter_spec.rb
+++ b/spec/integration/dragnet/exporters/json_exporter_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
             '"refs":["ESR_REQ_9126"],' \
             '"result":"passed",' \
             '"review_status":"not_reviewed",' \
+            '"mtr_file":"MTR/PD_3234_voltage.yaml",' \
             '"verification_result":{' \
               '"status":"skipped",' \
               '"started_at":"2024-02-27 14:36:07 +0000",' \
@@ -168,6 +169,7 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
             '"refs":["ESR_REQ_7817","ESR_REQ_3636"],' \
             '"result":"passed",' \
             '"review_status":"reviewed",' \
+            '"mtr_file":"MTR/validators.yaml",' \
             '"verification_result":{' \
               '"status":"passed",' \
               '"started_at":"2024-02-27 14:21:16 +0000",' \
@@ -190,6 +192,7 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
             '"refs":["ESR_REQ_7661"],' \
             '"result":"failed",' \
             '"review_status":"not_reviewed",' \
+            '"mtr_file":"MTR/crypto/diffie.yaml",' \
             '"verification_result":{' \
               '"status":"failed",' \
               '"started_at":"2024-02-27 14:22:04 +0000",' \
@@ -243,6 +246,10 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
 
         it 'includes the Verification Result for each MTR', requirements: %w[SRS_DRAGNET_0062] do
           expect(verification_results).to all(be_a(Hash))
+        end
+
+        it "includes the MTRs' file names", requirements: %w[SRS_DRAGNET_0081] do
+          expect(re_parsed_json).to all(have_key('mtr_file'))
         end
 
         it 'includes the start_at attribute in each Verification Result', requirements: %w[SRS_DRAGNET_0078] do


### PR DESCRIPTION
This pull request adds the necessary code to include the MTRs' file names in the JSON export.

The main driver behind this change is the need to quickly find out the source of a manual test result that has been pushed to Elasticsearch, since the ID of the MTRs not necessarily have to match the name of files that contain them.