### PR TITLE
[ELITERT-1205] Fix requirements linking in tests

### DIFF
--- a/spec/dragnet/cli/master_spec.rb
+++ b/spec/dragnet/cli/master_spec.rb
@@ -59,7 +59,7 @@ end
 RSpec.describe Dragnet::CLI::Master do
   subject(:master) { described_class.new }
 
-  describe '#version', requirements: %w[DRAGNET_0017 DRAGNET_0026] do
+  describe '#version', requirements: %w[SRS_DRAGNET_0017 SRS_DRAGNET_0026] do
     subject(:method_call) { master.version }
 
     include_context "with the default CLI's --version output"
@@ -79,7 +79,7 @@ RSpec.describe Dragnet::CLI::Master do
     end
   end
 
-  describe '#check', requirements: ['DRAGNET_0018'] do
+  describe '#check', requirements: ['SRS_DRAGNET_0018'] do
     subject(:method_call) { master.check(path) }
 
     let(:path) { nil }
@@ -154,13 +154,13 @@ RSpec.describe Dragnet::CLI::Master do
     end
 
     context 'when no configuration file is specified' do
-      it 'loads the default configuration file', requirements: ['DRAGNET_0019'] do
+      it 'loads the default configuration file', requirements: ['SRS_DRAGNET_0019'] do
         expect(File).to receive(:read).with('.dragnet.yaml')
         method_call
       end
     end
 
-    context 'when a configuration file is specified', requirements: ['DRAGNET_0020'] do
+    context 'when a configuration file is specified', requirements: ['SRS_DRAGNET_0020'] do
       before do
         master.options = { configuration: 'my_config.yaml' }
         allow(File).to receive(:read).with('my_config.yaml').and_return(config_yaml)
@@ -172,7 +172,7 @@ RSpec.describe Dragnet::CLI::Master do
       end
     end
 
-    context 'when the specified configuration file cannot be loaded', requirements: ['DRAGNET_0034'] do
+    context 'when the specified configuration file cannot be loaded', requirements: ['SRS_DRAGNET_0034'] do
       before do
         allow(File).to receive(:read).with('.dragnet.yaml').and_raise(
           Errno::ENOENT, 'File not found .dragnet.yaml'
@@ -198,7 +198,7 @@ RSpec.describe Dragnet::CLI::Master do
       end
     end
 
-    context 'when no path is specified', requirements: %w[DRAGNET_0001 DRAGNET_0002] do
+    context 'when no path is specified', requirements: %w[SRS_DRAGNET_0001 SRS_DRAGNET_0002] do
       context 'when none is configured in the configuration file' do
         let(:pwd) { Pathname.pwd }
 
@@ -304,7 +304,7 @@ RSpec.describe Dragnet::CLI::Master do
       end
     end
 
-    context 'when a path is specified', requirements: %w[DRAGNET_0001 DRAGNET_0002] do
+    context 'when a path is specified', requirements: %w[SRS_DRAGNET_0001 SRS_DRAGNET_0002] do
       let(:path) { '/tmp/repository' }
       let(:pathname) { Pathname.new('/tmp/repository') }
 
@@ -363,7 +363,7 @@ RSpec.describe Dragnet::CLI::Master do
       method_call
     end
 
-    context 'when the Explorer class raises an ArgumentError', requirements: ['DRAGNET_0034'] do
+    context 'when the Explorer class raises an ArgumentError', requirements: ['SRS_DRAGNET_0034'] do
       before do
         allow(Dragnet::Explorer).to receive(:new).and_raise(
           ArgumentError, 'Missing required parameter glob_patterns'
@@ -389,7 +389,7 @@ RSpec.describe Dragnet::CLI::Master do
       end
     end
 
-    context 'when the Explorer raises a Dragnet::Errors::NoMTRFilesFoundError', requirements: ['DRAGNET_0033'] do
+    context 'when the Explorer raises a Dragnet::Errors::NoMTRFilesFoundError', requirements: ['SRS_DRAGNET_0033'] do
       before do
         allow(explorer).to receive(:files).and_raise(
           Dragnet::Errors::NoMTRFilesFoundError,

--- a/spec/dragnet/explorer_spec.rb
+++ b/spec/dragnet/explorer_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Dragnet::Explorer do
     )
   end
 
-  describe '#initialize', requirements: %w[DRAGNET_0001 DRAGNET_0002] do
+  describe '#initialize', requirements: %w[SRS_DRAGNET_0001 SRS_DRAGNET_0002] do
     subject(:method_call) { explorer }
 
-    describe 'parameter checks', requirements: ['DRAGNET_0034'] do
+    describe 'parameter checks', requirements: ['SRS_DRAGNET_0034'] do
       context 'when the path is missing' do
         let(:path) { nil }
 
@@ -83,7 +83,7 @@ RSpec.describe Dragnet::Explorer do
   describe '#files' do
     subject(:method_call) { explorer.files }
 
-    context 'when no files are found on the given path', requirements: ['DRAGNET_0033'] do
+    context 'when no files are found on the given path', requirements: ['SRS_DRAGNET_0033'] do
       before do
         allow(path).to receive(:glob).with('tests/manual/*.yaml').and_return([])
       end
@@ -109,7 +109,7 @@ RSpec.describe Dragnet::Explorer do
       end
 
       shared_examples_for '#files when the explorer finds files' do
-        it 'logs the found MTR files', requirements: %w[DRAGNET_0032] do
+        it 'logs the found MTR files', requirements: %w[SRS_DRAGNET_0032] do
           expect(logger).to receive(:info).with('Found MTR file: /Workspace/source/tests/manual/ESR_9473.yaml')
           expect(logger).to receive(:info).with('Found MTR file: /Workspace/source/tests/manual/ESR_1532.yaml')
           method_call
@@ -143,7 +143,7 @@ RSpec.describe Dragnet::Explorer do
 
         it_behaves_like '#files when the explorer finds files'
 
-        it 'logs the MTR found in the second glob pattern', requirements: %w[DRAGNET_0032] do
+        it 'logs the MTR found in the second glob pattern', requirements: %w[SRS_DRAGNET_0032] do
           expect(logger).to receive(:info).with('Found MTR file: /Workspace/source/req/manual/ESR_6348.yml')
           method_call
         end

--- a/spec/dragnet/exporter_spec.rb
+++ b/spec/dragnet/exporter_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Dragnet::Exporter do
         method_call
       end
 
-      it 'writes the output to the JSON target', requirements: %w[DRAGNET_0060] do
+      it 'writes the output to the JSON target', requirements: %w[SRS_DRAGNET_0060] do
         expect(File).to receive(:write).with('output/report.json', json_output)
         method_call
       end

--- a/spec/dragnet/exporters/html_exporter_spec.rb
+++ b/spec/dragnet/exporters/html_exporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'dragnet/exporters/html_exporter'
 
-RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['DRAGNET_0022'] do
+RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_0022'] do
   subject(:html_exporter) do
     described_class.new(
       test_records: test_records, errors: errors, repository: repository, logger: logger

--- a/spec/dragnet/exporters/id_generator_spec.rb
+++ b/spec/dragnet/exporters/id_generator_spec.rb
@@ -4,7 +4,7 @@ require 'dragnet/exporters/id_generator'
 require 'dragnet/multi_repository'
 require 'dragnet/test_record'
 
-RSpec.describe Dragnet::Exporters::IDGenerator, requirements: %w[DRAGNET_0067] do
+RSpec.describe Dragnet::Exporters::IDGenerator, requirements: %w[SRS_DRAGNET_0067] do
   subject(:id_generator) { described_class.new(repository) }
 
   let(:repository) do

--- a/spec/dragnet/exporters/json_exporter_spec.rb
+++ b/spec/dragnet/exporters/json_exporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'dragnet/exporters/json_exporter'
 
-RSpec.describe Dragnet::Exporters::JSONExporter, requirements: %w[DRAGNET_0060] do
+RSpec.describe Dragnet::Exporters::JSONExporter, requirements: %w[SRS_DRAGNET_0060] do
   subject(:json_exporter) do
     described_class.new(test_records: test_records, errors: errors, repository: repository, logger: logger)
   end
@@ -115,12 +115,12 @@ RSpec.describe Dragnet::Exporters::JSONExporter, requirements: %w[DRAGNET_0060] 
       method_call
     end
 
-    it 'creates a single instance of the IDGenerator class', requirements: %w[DRAGNET_0066] do
+    it 'creates a single instance of the IDGenerator class', requirements: %w[SRS_DRAGNET_0066] do
       expect(Dragnet::Exporters::IDGenerator).to receive(:new).with(repository).once
       method_call
     end
 
-    it 'generates IDs for each of the Test Records', requirements: %w[DRAGNET_0066] do
+    it 'generates IDs for each of the Test Records', requirements: %w[SRS_DRAGNET_0066] do
       test_records.each do |test_record|
         expect(id_generator).to receive(:id_for).with(test_record)
       end
@@ -149,12 +149,12 @@ RSpec.describe Dragnet::Exporters::JSONExporter, requirements: %w[DRAGNET_0060] 
           expect(parsed_json).to be_an(Array)
         end
 
-        it 'produces an Array of Hashes', requirements: %w[DRAGNET_0061] do
+        it 'produces an Array of Hashes', requirements: %w[SRS_DRAGNET_0061] do
           expect(parsed_json).to all(be_a(Hash))
         end
 
         it 'produces an array with the same number of elements as Test Records there are',
-           requirements: %w[DRAGNET_0061] do
+           requirements: %w[SRS_DRAGNET_0061] do
           expect(parsed_json.size).to eq(test_records.size)
         end
       end

--- a/spec/dragnet/exporters/serializers/test_record_serializer_spec.rb
+++ b/spec/dragnet/exporters/serializers/test_record_serializer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
     context 'when the ID of the Test Record is a String' do
       let(:id) { 'ESR_REQ_7630' }
 
-      it 'includes the expected Array of "refs"', requirements: %w[DRAGNET_0064] do
+      it 'includes the expected Array of "refs"', requirements: %w[SRS_DRAGNET_0064] do
         expect(method_call).to include(refs: [id])
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
     context 'when the ID of the Test Record is an Array' do
       let(:id) { %w[ESR_REQ_1008 ESR_REQ_1065] }
 
-      it 'includes the expected Array of "refs"', requirements: %w[DRAGNET_0064] do
+      it 'includes the expected Array of "refs"', requirements: %w[SRS_DRAGNET_0064] do
         expect(method_call).to include(refs: id)
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
     context "when the TestRecord doesn't have the tester's name" do
       let(:name) { nil }
 
-      it 'does not include the :owner key', requirements: %w[DRAGNET_0071] do
+      it 'does not include the :owner key', requirements: %w[SRS_DRAGNET_0071] do
         expect(method_call).not_to have_key(:owner)
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
       context 'when there is a single tester' do
         let(:name) { ['Freddy Mercury'] }
 
-        it "includes the tester's name (as 'owner')", requirements: %w[DRAGNET_0065] do
+        it "includes the tester's name (as 'owner')", requirements: %w[SRS_DRAGNET_0065] do
           expect(method_call).to include(owner: 'Freddy Mercury')
         end
       end
@@ -135,7 +135,7 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
       context 'when there are multiple testers' do
         let(:name) { ['Freddy Mercury', 'Brian May', 'John Deacon', 'Roger Taylor'] }
 
-        it "includes all the testers' names as a single string", requirements: %w[DRAGNET_0071] do
+        it "includes all the testers' names as a single string", requirements: %w[SRS_DRAGNET_0071] do
           expect(method_call).to include(owner: 'Freddy Mercury, Brian May, John Deacon, Roger Taylor')
         end
       end
@@ -166,12 +166,12 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
     context "when the TestRecord doesn't have a test method" do
       let(:test_method) { nil }
 
-      it 'does not include the :test_method key', requirements: %w[DRAGNET_0070] do
+      it 'does not include the :test_method key', requirements: %w[SRS_DRAGNET_0070] do
         expect(method_call).not_to have_key(:test_method)
       end
     end
 
-    context 'when the TestRecord has a test method', requirements: %w[DRAGNET_0070] do
+    context 'when the TestRecord has a test method', requirements: %w[SRS_DRAGNET_0070] do
       context 'when there is a single method' do
         let(:test_method) { 'Failure injection' }
 
@@ -192,12 +192,12 @@ RSpec.describe Dragnet::Exporters::Serializers::TestRecordSerializer do
     context "when the TestRecord doesn't have a derivation method" do
       let(:tc_derivation_method) { nil }
 
-      it 'does not include the :tc_derivation_method key', requirements: %w[DRAGNET_0070] do
+      it 'does not include the :tc_derivation_method key', requirements: %w[SRS_DRAGNET_0070] do
         expect(method_call).not_to have_key(:tc_derivation_method)
       end
     end
 
-    context 'when the TestRecord has a derivation method', requirements: %w[DRAGNET_0070] do
+    context 'when the TestRecord has a derivation method', requirements: %w[SRS_DRAGNET_0070] do
       context 'when there is a single method' do
         let(:tc_derivation_method) { 'Decision tree' }
 

--- a/spec/dragnet/repo_spec.rb
+++ b/spec/dragnet/repo_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dragnet::Repo do
     context 'without files' do
       let(:params) { { path: path, sha1: sha1 } }
 
-      it 'does not raise any errors', requirements: ['DRAGNET_0049'] do
+      it 'does not raise any errors', requirements: ['SRS_DRAGNET_0049'] do
         expect { repo }.not_to raise_error
       end
     end
@@ -23,7 +23,7 @@ RSpec.describe Dragnet::Repo do
     context 'when files is nil' do
       let(:files) { nil }
 
-      it 'does not rise any errors', requirements: ['DRAGNET_0049'] do
+      it 'does not rise any errors', requirements: ['SRS_DRAGNET_0049'] do
         expect { repo }.not_to raise_error
       end
     end

--- a/spec/dragnet/test_record_spec.rb
+++ b/spec/dragnet/test_record_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Dragnet::TestRecord do
       end
     end
 
-    describe 'Meta-data', requirements: %w[DRAGNET_0068] do
+    describe 'Meta-data', requirements: %w[SRS_DRAGNET_0068] do
       shared_examples_for 'a meta-data attribute' do
         # Required variables:
         #   :attribute_value: The value attribute being tested

--- a/spec/dragnet/validator_spec.rb
+++ b/spec/dragnet/validator_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Dragnet::Validator do
       end
     end
 
-    it 'Logs the files as they are checked', requirements: %w[DRAGNET_0027] do
+    it 'Logs the files as they are checked', requirements: %w[SRS_DRAGNET_0027] do
       files.each do |file|
         expect(logger).to receive(:info).with("Validating #{file}...")
       end
@@ -126,7 +126,7 @@ RSpec.describe Dragnet::Validator do
       include_examples 'Dragnet::Validator#validate adds the file data to the errors array'
     end
 
-    context 'when one of the files is not a valid YAML file', requirements: ['DRAGNET_0003'] do
+    context 'when one of the files is not a valid YAML file', requirements: ['SRS_DRAGNET_0003'] do
       let(:file) { '/Workspace/source/test/manual/ESR_REQ_9813.yaml' }
 
       let(:malformed_yaml) do
@@ -292,7 +292,7 @@ RSpec.describe Dragnet::Validator do
         expect { method_call }.not_to raise_error
       end
 
-      context "when one of the Repos' path doesn't exist", requirements: %w[DRAGNET_0058] do
+      context "when one of the Repos' path doesn't exist", requirements: %w[SRS_DRAGNET_0058] do
         let(:exception_message) do
           'Cannot find the repository path path/to/the/repo inside /Workspace/source'
         end
@@ -314,7 +314,7 @@ RSpec.describe Dragnet::Validator do
       end
 
       context "when one or more of the files listed in the Repo doesn't exist",
-              requirements: %w[DRAGNET_0047 DRAGNET_0048] do
+              requirements: %w[SRS_DRAGNET_0047 SRS_DRAGNET_0048] do
 
         let(:exception_message) do
           'Could not find any files matching lib/security/crypto/rsa*.h in path/to/the/repo'

--- a/spec/dragnet/validators/data_validator_spec.rb
+++ b/spec/dragnet/validators/data_validator_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Dragnet::Validators::DataValidator do
   describe '#validate' do
     subject(:method_call) { data_validator.validate }
 
-    context 'when the data is not a hash', requirements: %w[DRAGNET_0006 DRAGNET_0007 DRAGNET_0008] do
+    context 'when the data is not a hash', requirements: %w[SRS_DRAGNET_0006 SRS_DRAGNET_0007 SRS_DRAGNET_0008] do
       let(:data) { 'The quick brown fox...' }
 
       let(:expected_message) do

--- a/spec/dragnet/validators/entities/repo_validator_spec.rb
+++ b/spec/dragnet/validators/entities/repo_validator_spec.rb
@@ -60,12 +60,12 @@ RSpec.describe Dragnet::Validators::Entities::RepoValidator do
       end
     end
 
-    it 'uses the SHA1Validator class to validate the `sha1` attribute', requirements: ['DRAGNET_0043'] do
+    it 'uses the SHA1Validator class to validate the `sha1` attribute', requirements: ['SRS_DRAGNET_0043'] do
       expect(sha1_validator).to receive(:validate).with('repos[sha1]', sha1)
       method_call
     end
 
-    context 'when the SHA1Validator fails', requirements: ['DRAGNET_0046'] do
+    context 'when the SHA1Validator fails', requirements: ['SRS_DRAGNET_0046'] do
       let(:validator) { sha1_validator }
       let(:validation_error) { Dragnet::Errors::ValidationError }
       let(:message) { 'Missing required key: repos[sha1]' }
@@ -73,12 +73,12 @@ RSpec.describe Dragnet::Validators::Entities::RepoValidator do
       include_context 'when an individual validator fails'
     end
 
-    it 'uses the PathValidator class to validate the `path` attribute', requirements: ['DRAGNET_0039'] do
+    it 'uses the PathValidator class to validate the `path` attribute', requirements: ['SRS_DRAGNET_0039'] do
       expect(path_validator).to receive(:validate).with('repos[path]', path)
       method_call
     end
 
-    context 'when the PathValidator fails', requirements: ['DRAGNET_0042'] do
+    context 'when the PathValidator fails', requirements: ['SRS_DRAGNET_0042'] do
       let(:validator) { path_validator }
       let(:validation_error) { Dragnet::Errors::ValidationError }
 
@@ -89,7 +89,7 @@ RSpec.describe Dragnet::Validators::Entities::RepoValidator do
       include_context 'when an individual validator fails'
     end
 
-    context 'when the Repo has files', requirements: ['DRAGNET_0041'] do
+    context 'when the Repo has files', requirements: ['SRS_DRAGNET_0041'] do
       let(:files) { 'utils/b2f/password.c' }
       let(:processed_files) { ['utils/b2f/password.c'] }
 

--- a/spec/dragnet/validators/entities/test_record_validator_spec.rb
+++ b/spec/dragnet/validators/entities/test_record_validator_spec.rb
@@ -119,19 +119,19 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
     context 'when the MTR has neither a `files` nor a `repos` attribute' do
       let(:files) { nil }
 
-      it 'passes the validation', requirements: %w[DRAGNET_0055 DRAGNET_0056] do
+      it 'passes the validation', requirements: %w[SRS_DRAGNET_0055 SRS_DRAGNET_0056] do
         expect { method_call }.not_to raise_error
       end
     end
 
     context 'when the MTR has a `files` attribute but no `repos` attribute' do
-      it 'passes the validation', requirements: %w[DRAGNET_0004] do
+      it 'passes the validation', requirements: %w[SRS_DRAGNET_0004] do
         expect { method_call }.not_to raise_error
       end
     end
 
     context 'when the MTR has a `repos` attribute but no `files` attribute' do
-      it 'passes the validation', requirements: %w[DRAGNET_0035] do
+      it 'passes the validation', requirements: %w[SRS_DRAGNET_0035] do
         expect { method_call }.not_to raise_error
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
         ]
       end
 
-      it 'fails the validation', requirements: %w[DRAGNET_0036] do
+      it 'fails the validation', requirements: %w[SRS_DRAGNET_0036] do
         expect { method_call }.to raise_error(
           Dragnet::Errors::ValidationError,
           "Invalid MTR: ESR_REQ_5435. Either 'files' or 'repos' should be provided, not both"
@@ -153,12 +153,12 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
     end
 
     context 'when the MTR has a SHA1 but not a list of repositories' do
-      it 'uses the SHA1 Validator to validate', requirements: ['DRAGNET_0006'] do
+      it 'uses the SHA1 Validator to validate', requirements: ['SRS_DRAGNET_0006'] do
         expect(sha1_validator).to receive(:validate).with('sha1', sha1)
         method_call
       end
 
-      context 'when the SHA1 validation fails', requirements: ['DRAGNET_0006'] do
+      context 'when the SHA1 validation fails', requirements: ['SRS_DRAGNET_0006'] do
         let(:exception) { Dragnet::Errors::ValidationError }
         let(:message) { 'missing key sha1' }
         let(:validator) { sha1_validator }
@@ -179,7 +179,7 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
       let(:files) { nil }
       let(:repos) { [{ a: 'repo' }, { b: 'repo' }, { c: 'repo' }] }
 
-      it 'raises a Dragnet::Errors::ValidationError', requirements: %w[DRAGNET_0057] do
+      it 'raises a Dragnet::Errors::ValidationError', requirements: %w[SRS_DRAGNET_0057] do
         expect { method_call }.to raise_error(
           Dragnet::Errors::ValidationError,
           "Invalid MTR: ESR_REQ_5435. Either 'repos' or 'sha1' should be provided, not both"
@@ -238,13 +238,13 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
         [instance_double(Dragnet::Repo), instance_double(Dragnet::Repo)]
       end
 
-      it 'does not validate the SHA1 attribute', requirements: ['DRAGNET_0057'] do
+      it 'does not validate the SHA1 attribute', requirements: ['SRS_DRAGNET_0057'] do
         expect(Dragnet::Validators::Fields::SHA1Validator).not_to receive(:new)
         expect(sha1_validator).not_to receive(:validate)
         method_call
       end
 
-      it 'uses the ReposValidator to validate the repos', requirements: ['DRAGNET_0037'] do
+      it 'uses the ReposValidator to validate the repos', requirements: ['SRS_DRAGNET_0037'] do
         expect(repos_validator).to receive(:validate).with('repos', repos)
         method_call
       end
@@ -284,7 +284,7 @@ RSpec.describe Dragnet::Validators::Entities::TestRecordValidator do
       include_context 'when an individual validator fails'
     end
 
-    describe 'meta-data validation', requirements: %w[DRAGNET_0068] do
+    describe 'meta-data validation', requirements: %w[SRS_DRAGNET_0068] do
       let(:name) { 'Bruce Willis' }
       let(:test_method) { 'Nuclear explosion' }
       let(:tc_derivation_method) { 'BVA' }

--- a/spec/dragnet/validators/fields/id_validator_spec.rb
+++ b/spec/dragnet/validators/fields/id_validator_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Dragnet::Validators::Fields::IDValidator do
       end
     end
 
-    context "when the data doesn't have an id key", requirements: ['DRAGNET_0007'] do
+    context "when the data doesn't have an id key", requirements: ['SRS_DRAGNET_0007'] do
       let(:value) { nil }
       let(:expected_message) { 'Missing required key: id' }
 
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the id key has an invalid data type', requirements: ['DRAGNET_0007'] do
+    context 'when the id key has an invalid data type', requirements: ['SRS_DRAGNET_0007'] do
       let(:value) { 6754.54 }
 
       let(:expected_message) do
@@ -36,7 +36,7 @@ RSpec.describe Dragnet::Validators::Fields::IDValidator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the id key has multiple IDs in a string', requirements: ['DRAGNET_0007'] do
+    context 'when the id key has multiple IDs in a string', requirements: ['SRS_DRAGNET_0007'] do
       let(:value) { 'ERS_REQ_6845, ESR_REQ_9459' }
 
       let(:expected_message) do
@@ -47,7 +47,7 @@ RSpec.describe Dragnet::Validators::Fields::IDValidator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the array of IDs has something that is not a string', requirements: ['DRAGNET_0007'] do
+    context 'when the array of IDs has something that is not a string', requirements: ['SRS_DRAGNET_0007'] do
       let(:value) { ['ESR_REQ_3175', 2 + 3i, 'ESR_REQ_8518'] }
 
       let(:expected_message) do

--- a/spec/dragnet/validators/fields/meta_data_field_validator_spec.rb
+++ b/spec/dragnet/validators/fields/meta_data_field_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'dragnet/validators/fields/meta_data_field_validator'
 
-RSpec.describe Dragnet::Validators::Fields::MetaDataFieldValidator, requirements: %w[DRAGNET_0068] do
+RSpec.describe Dragnet::Validators::Fields::MetaDataFieldValidator, requirements: %w[SRS_DRAGNET_0068] do
   subject(:meta_data_field_validator) { described_class.new }
 
   describe '#validate' do

--- a/spec/dragnet/validators/fields/repos_validator_spec.rb
+++ b/spec/dragnet/validators/fields/repos_validator_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dragnet::Validators::Fields::ReposValidator do
       end
     end
 
-    context 'when the value is an Array', requirements: ['DRAGNET_0037'] do
+    context 'when the value is an Array', requirements: ['SRS_DRAGNET_0037'] do
       context 'when the array is empty' do
         let(:value) { [] }
 

--- a/spec/dragnet/validators/fields/result_validator_spec.rb
+++ b/spec/dragnet/validators/fields/result_validator_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe Dragnet::Validators::Fields::ResultValidator do
       end
     end
 
-    context "when the data doesn't have a result key", requirements: ['DRAGNET_0008'] do
+    context "when the data doesn't have a result key", requirements: ['SRS_DRAGNET_0008'] do
       let(:value) { nil }
       let(:expected_message) { 'Missing required key: result' }
 
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the result key contains something that is not a string', requirements: ['DRAGNET_0008'] do
+    context 'when the result key contains something that is not a string', requirements: ['SRS_DRAGNET_0008'] do
       let(:value) { /missed/ }
 
       let(:expected_message) do
@@ -44,7 +44,7 @@ RSpec.describe Dragnet::Validators::Fields::ResultValidator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the value of the result field is not valid', requirements: ['DRAGNET_0008'] do
+    context 'when the value of the result field is not valid', requirements: ['SRS_DRAGNET_0008'] do
       let(:value) { 'missed' }
 
       let(:expected_message) do

--- a/spec/dragnet/validators/fields/sha1_validator_spec.rb
+++ b/spec/dragnet/validators/fields/sha1_validator_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Dragnet::Validators::Fields::SHA1Validator do
       end
     end
 
-    context "when the data doesn't have a sha1 key", requirements: ['DRAGNET_0006'] do
+    context "when the data doesn't have a sha1 key", requirements: ['SRS_DRAGNET_0006'] do
       let(:value) { nil }
       let(:expected_message) { 'Missing required key: sha1' }
 
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the SHA1 is not a string', requirements: ['DRAGNET_0006'] do
+    context 'when the SHA1 is not a string', requirements: ['SRS_DRAGNET_0006'] do
       let(:value) { 123_456 }
 
       let(:expected_message) do
@@ -36,7 +36,7 @@ RSpec.describe Dragnet::Validators::Fields::SHA1Validator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the SHA1 is too short', requirements: ['DRAGNET_0006'] do
+    context 'when the SHA1 is too short', requirements: ['SRS_DRAGNET_0006'] do
       let(:value) { 'af27' }
 
       let(:expected_message) do
@@ -46,7 +46,7 @@ RSpec.describe Dragnet::Validators::Fields::SHA1Validator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the SHA1 is too long', requirements: ['DRAGNET_0006'] do
+    context 'when the SHA1 is too long', requirements: ['SRS_DRAGNET_0006'] do
       let(:value) { 'ca3a9455ae12dc3a1939a3152d82250cc9ed001a1f8736b43010a41702b' }
 
       let(:expected_message) do
@@ -56,7 +56,7 @@ RSpec.describe Dragnet::Validators::Fields::SHA1Validator do
       it_behaves_like 'Dragnet::Validators::Fields::FieldValidator#validate when the validation fails'
     end
 
-    context 'when the SHA1 is not a valid hexadecimal string', requirements: ['DRAGNET_0006'] do
+    context 'when the SHA1 is not a valid hexadecimal string', requirements: ['SRS_DRAGNET_0006'] do
       let(:value) { '...jumped over the lazy gray dog' }
 
       let(:expected_message) do

--- a/spec/dragnet/validators/files_validator_spec.rb
+++ b/spec/dragnet/validators/files_validator_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Dragnet::Validators::FilesValidator do
   describe '#validate' do
     subject(:method_call) { files_validator.validate }
 
-    context 'when the files key is not present or has no value', requirements: ['DRAGNET_0004'] do
+    context 'when the files key is not present or has no value', requirements: ['SRS_DRAGNET_0004'] do
       let(:files) { nil }
 
       it 'does nothing' do
@@ -58,7 +58,7 @@ RSpec.describe Dragnet::Validators::FilesValidator do
       end
     end
 
-    context "when one of the given files doesn't match a file in the repository", requirements: ['DRAGNET_0005'] do
+    context "when one of the given files doesn't match a file in the repository", requirements: ['SRS_DRAGNET_0005'] do
       let(:file) { 'test/manual/ESR_REQ_5745.yaml' }
 
       before do
@@ -72,7 +72,7 @@ RSpec.describe Dragnet::Validators::FilesValidator do
       end
     end
 
-    context 'when a glob pattern is given', requirements: %w[DRAGNET_0013 DRAGNET_0014] do
+    context 'when a glob pattern is given', requirements: %w[SRS_DRAGNET_0013 SRS_DRAGNET_0014] do
       let(:files) { ['test/manual/security/ESR_REQ_*.yaml'] }
 
       let(:expected_files) do
@@ -102,7 +102,7 @@ RSpec.describe Dragnet::Validators::FilesValidator do
     end
 
     context 'when the listed files or glob patterns have a / at the beginning',
-            requirements: %w[DRAGNET_0072 DRAGNET_0073] do
+            requirements: %w[SRS_DRAGNET_0072 SRS_DRAGNET_0073] do
       let(:files) do
         %w[
           /test/manual/safety/ESR_REQ_*.yaml

--- a/spec/dragnet/validators/repos_validator_spec.rb
+++ b/spec/dragnet/validators/repos_validator_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Dragnet::Validators::ReposValidator do
         end
       end
 
-      context 'when the repo has a relative path', requirements: %w[DRAGNET_0039] do
+      context 'when the repo has a relative path', requirements: %w[SRS_DRAGNET_0039] do
         let(:complete_path) { instance_double(Pathname, exist?: complete_exists) }
 
         it 'creates a path by joining the workspace path with the path of the repo' do
@@ -130,7 +130,7 @@ RSpec.describe Dragnet::Validators::ReposValidator do
         context "when the repo path doesn't exist" do
           let(:complete_exists) { false }
 
-          it 'raises a Dragnet::Errors::RepoPathNotFoundError', requirements: %w[DRAGNET_0058] do
+          it 'raises a Dragnet::Errors::RepoPathNotFoundError', requirements: %w[SRS_DRAGNET_0058] do
             expect { method_call }.to raise_error(
               Dragnet::Errors::RepoPathNotFoundError,
               'Cannot find the repository path path/to/repo inside /workspace/source'
@@ -139,7 +139,7 @@ RSpec.describe Dragnet::Validators::ReposValidator do
         end
       end
 
-      context 'when the repo has an absolute path', requirements: %w[DRAGNET_0039] do
+      context 'when the repo has an absolute path', requirements: %w[SRS_DRAGNET_0039] do
         it 'verifies the existence of the given path directly' do
           expect(absolute_path).to receive(:exist?)
           method_call
@@ -148,7 +148,7 @@ RSpec.describe Dragnet::Validators::ReposValidator do
         context "when the repo path doesn't exist" do
           let(:absolute_exists) { false }
 
-          it 'raises a Dragnet::Errors::RepoPathNotFoundError', requirements: %w[DRAGNET_0058] do
+          it 'raises a Dragnet::Errors::RepoPathNotFoundError', requirements: %w[SRS_DRAGNET_0058] do
             expect { method_call }.to raise_error(
               Dragnet::Errors::RepoPathNotFoundError,
               'Cannot find the repository path /workspace/some/other/repo'
@@ -157,7 +157,7 @@ RSpec.describe Dragnet::Validators::ReposValidator do
         end
       end
 
-      context 'when the repos have no files', requirements: %w[DRAGNET_0049] do
+      context 'when the repos have no files', requirements: %w[SRS_DRAGNET_0049] do
         let(:files) { nil }
 
         it 'does not perform any validation over files' do
@@ -182,7 +182,8 @@ RSpec.describe Dragnet::Validators::ReposValidator do
           allow(files_validator).to receive(:validate).and_raise(*expected_error)
         end
 
-        it 'raises a Dragnet::Errors::FileNotFoundError', requirements: %w[DRAGNET_0044 DRAGNET_0047 DRAGNET_0048] do
+        it 'raises a Dragnet::Errors::FileNotFoundError',
+           requirements: %w[SRS_DRAGNET_0044 SRS_DRAGNET_0047 SRS_DRAGNET_0048] do
           expect { method_call }.to raise_error(*expected_error)
         end
       end

--- a/spec/dragnet/verification_result_spec.rb
+++ b/spec/dragnet/verification_result_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Dragnet::VerificationResult do
   end
 
   shared_examples 'runtime update after timestamp change' do
-    describe 'runtime update', requirements: %w[DRAGNET_0077] do
+    describe 'runtime update', requirements: %w[SRS_DRAGNET_0077] do
       before do
         verification_result.started_at = Time.new(2028, 2, 6, 22, 40, 24)
         verification_result.finished_at = Time.new(2032, 9, 17, 6, 3, 18)
@@ -142,7 +142,7 @@ RSpec.describe Dragnet::VerificationResult do
     end
   end
 
-  describe '#started_at=', requirements: %w[DRAGNET_0075] do
+  describe '#started_at=', requirements: %w[SRS_DRAGNET_0075] do
     subject(:method_call) { verification_result.started_at = time }
 
     let(:time) { Time.new(2024, 1, 31, 11, 20, 12) }
@@ -179,7 +179,7 @@ RSpec.describe Dragnet::VerificationResult do
     end
   end
 
-  describe '#finished_at=', requirements: %w[DRAGNET_0076] do
+  describe '#finished_at=', requirements: %w[SRS_DRAGNET_0076] do
     subject(:method_call) { verification_result.finished_at = time }
 
     let(:time) { Time.new(2031, 1, 24, 12, 20, 11) }
@@ -227,7 +227,7 @@ RSpec.describe Dragnet::VerificationResult do
     end
   end
 
-  describe '#runtime!', requirements: %w[DRAGNET_0077] do
+  describe '#runtime!', requirements: %w[SRS_DRAGNET_0077] do
     subject(:method_call) { verification_result.runtime! }
 
     shared_examples_for '#runtime! when started_at or finished_at are nil' do
@@ -260,7 +260,7 @@ RSpec.describe Dragnet::VerificationResult do
     end
   end
 
-  describe '#runtime', requirements: %w[DRAGNET_0077] do
+  describe '#runtime', requirements: %w[SRS_DRAGNET_0077] do
     subject(:method_call) { verification_result.runtime }
 
     context 'when both started_at and finished_at are nil' do
@@ -307,7 +307,7 @@ RSpec.describe Dragnet::VerificationResult do
         )
       end
 
-      it 'returns the expected log message', requirements: %w[DRAGNET_0029] do
+      it 'returns the expected log message', requirements: %w[SRS_DRAGNET_0029] do
         expect(method_call).to eq(
           "\e[0;93;49m⚠ SKIPPED\e[0m Changes detected in listed file(s): df0a857bc9..b00826b104 -- src/crypto/rsa.rs"
         )
@@ -323,7 +323,7 @@ RSpec.describe Dragnet::VerificationResult do
           )
         end
 
-        it 'returns the expected log message', requirements: %w[DRAGNET_0029] do
+        it 'returns the expected log message', requirements: %w[SRS_DRAGNET_0029] do
           expect(method_call).to eq(
             "\e[0;91;49m✘ FAILED \e[0m The path 'esrlabs/bsw/crypto' does not contain a valid git repository."
           )

--- a/spec/dragnet/verifier_spec.rb
+++ b/spec/dragnet/verifier_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe Dragnet::Verifier do
     end
 
     RSpec.shared_examples 'prints nothing to STDOUT' do
-      it 'prints nothing to STDOUT', requirements: ['DRAGNET_0031'] do
+      it 'prints nothing to STDOUT', requirements: ['SRS_DRAGNET_0031'] do
         expect { method_call }.not_to output.to_stdout
       end
     end
 
     include_examples 'prints nothing to STDOUT'
 
-    it 'passes all the Test Records through the TestRecordVerifier', requirements: ['DRAGNET_0030'] do
+    it 'passes all the Test Records through the TestRecordVerifier', requirements: ['SRS_DRAGNET_0030'] do
       test_records.each do |test_record|
         expect(Dragnet::Verifiers::TestRecordVerifier).to receive(:new)
           .with(test_record: test_record, repository: repository, test_records: test_records)
@@ -85,7 +85,7 @@ RSpec.describe Dragnet::Verifier do
       # Required variables:
       # :passed_test_records_count: The number of test records that should have passed the verification.
 
-      it 'logs the passing of all MTRs', requirements: %w[DRAGNET_0028] do
+      it 'logs the passing of all MTRs', requirements: %w[SRS_DRAGNET_0028] do
         expect(passed_verification_result).to receive(:log_message).exactly(passed_test_records_count).times
         expect(logger).to receive(:info).with('PASSED').exactly(passed_test_records_count).times
 
@@ -98,12 +98,12 @@ RSpec.describe Dragnet::Verifier do
       # :verification_result: The VerificationResult double that should receive the messages
       # :number_of_messages: The number of messages that should be received by the VerificationResult double
 
-      it 'records the started_at timestamp', requirements: %w[DRAGNET_0075] do
+      it 'records the started_at timestamp', requirements: %w[SRS_DRAGNET_0075] do
         expect(verification_result).to receive(:started_at=).with(instance_of(Time)).exactly(number_of_messages).times
         method_call
       end
 
-      it 'records the finished_at timestamp', requirements: %w[DRAGNET_0076] do
+      it 'records the finished_at timestamp', requirements: %w[SRS_DRAGNET_0076] do
         expect(verification_result).to receive(:finished_at=).with(instance_of(Time)).exactly(number_of_messages).times
         method_call
       end
@@ -172,7 +172,7 @@ RSpec.describe Dragnet::Verifier do
 
       include_examples 'prints nothing to STDOUT'
 
-      it 'logs the failure of the test record(s)', requirements: %w[DRAGNET_0028] do
+      it 'logs the failure of the test record(s)', requirements: %w[SRS_DRAGNET_0028] do
         expect(failed_verification_result).to receive(:log_message).exactly(failed_test_records_count).times
         expect(logger).to receive(:info).with('FAILED').exactly(failed_test_records_count).times
 
@@ -241,7 +241,7 @@ RSpec.describe Dragnet::Verifier do
 
       include_examples 'prints nothing to STDOUT'
 
-      it 'logs the skipping of the test record(s)', requirements: %w[DRAGNET_0028] do
+      it 'logs the skipping of the test record(s)', requirements: %w[SRS_DRAGNET_0028] do
         expect(skipped_verification_result).to receive(:log_message).exactly(skipped_test_records_count).times
         expect(logger).to receive(:info).with('SKIPPED').exactly(skipped_test_records_count).times
 

--- a/spec/dragnet/verifiers/changes_verifier_spec.rb
+++ b/spec/dragnet/verifiers/changes_verifier_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Dragnet::Verifiers::ChangesVerifier do
   describe '#verify' do
     subject(:method_call) { changes_verifier.verify }
 
-    context 'when there are no changes in the repository', requirements: ['DRAGNET_0016'] do
+    context 'when there are no changes in the repository', requirements: ['SRS_DRAGNET_0016'] do
       let(:diff) do
         instance_double(
           Git::Diff,
@@ -61,7 +61,7 @@ RSpec.describe Dragnet::Verifiers::ChangesVerifier do
       end
     end
 
-    context 'when there are changes in the repository', requirements: ['DRAGNET_0016'] do
+    context 'when there are changes in the repository', requirements: ['SRS_DRAGNET_0016'] do
       let(:diff) do
         instance_double(
           Git::Diff,
@@ -70,7 +70,7 @@ RSpec.describe Dragnet::Verifiers::ChangesVerifier do
         )
       end
 
-      context 'when the changes are only in MTR files', requirements: ['DRAGNET_0015'] do
+      context 'when the changes are only in MTR files', requirements: ['SRS_DRAGNET_0015'] do
         let(:stats) do
           {
             files: {
@@ -84,7 +84,7 @@ RSpec.describe Dragnet::Verifiers::ChangesVerifier do
         end
       end
 
-      context 'when the change include other files', requirements: ['DRAGNET_0015'] do
+      context 'when the change include other files', requirements: ['SRS_DRAGNET_0015'] do
         let(:stats) do
           {
             files: {

--- a/spec/dragnet/verifiers/files_verifier_spec.rb
+++ b/spec/dragnet/verifiers/files_verifier_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe Dragnet::Verifiers::FilesVerifier do
       end
     end
 
-    context 'when there are no changes in the listed files', requirements: ['DRAGNET_0016'] do
+    context 'when there are no changes in the listed files', requirements: ['SRS_DRAGNET_0016'] do
       it 'returns nil' do
         expect(method_call).to be_nil
       end
     end
 
-    context 'when one or more of the files have changes', requirements: %w[DRAGNET_0012 DRAGNET_0014] do
+    context 'when one or more of the files have changes', requirements: %w[SRS_DRAGNET_0012 SRS_DRAGNET_0014] do
       let(:changed_diff) do
         instance_double(
           Git::Diff,

--- a/spec/dragnet/verifiers/repos_verifier_spec.rb
+++ b/spec/dragnet/verifiers/repos_verifier_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
           .with(files: nil, sha1: '5ac903b80e').and_return(proxy_test_record_without_files)
       end
 
-      describe 'Repositories', requirements: %w[DRAGNET_0050] do
+      describe 'Repositories', requirements: %w[SRS_DRAGNET_0050] do
         it 'creates a Repository object for the Repo with files with the expected path' do
           expect(Dragnet::Repository).to receive(:new)
             .with(path: Pathname.new('/Workspace/project/source/esrlabs/bsw/crypto'))
@@ -155,7 +155,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
           end
         end
 
-        context 'when the creation of a repository fails', requirements: %w[DRAGNET_0045] do
+        context 'when the creation of a repository fails', requirements: %w[SRS_DRAGNET_0045] do
           let(:failed_verification_result) do
             instance_double(
               Dragnet::VerificationResult
@@ -187,7 +187,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
         end
       end
 
-      describe 'Proxy TestRecords', requirements: %w[DRAGNET_0050] do
+      describe 'Proxy TestRecords', requirements: %w[SRS_DRAGNET_0050] do
         it 'creates a proxy TestRecord for the first Repo with the expected parameters' do
           expect(Dragnet::TestRecord).to receive(:new).with(files: repo_files, sha1: '6fd07835de')
           method_call
@@ -200,7 +200,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
       end
 
       describe 'Verification' do
-        it 'verifies the Repo that has files with the FilesVerifier', requirements: %w[DRAGNET_0051] do
+        it 'verifies the Repo that has files with the FilesVerifier', requirements: %w[SRS_DRAGNET_0051] do
           expect(Dragnet::Verifiers::FilesVerifier).to receive(:new)
             .with(test_record: proxy_test_record_with_files, repository: repository_with_files)
 
@@ -208,7 +208,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
           method_call
         end
 
-        it 'verifies the Repo that has no files with the ChangesVerifier', requirements: %w[DRAGNET_0053] do
+        it 'verifies the Repo that has no files with the ChangesVerifier', requirements: %w[SRS_DRAGNET_0053] do
           expect(Dragnet::Verifiers::ChangesVerifier).to receive(:new)
             .with(test_record: proxy_test_record_without_files, repository: repository_without_files, test_records: [])
 
@@ -232,7 +232,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
           end
         end
 
-        context 'when the FilesVerifier fails', requirements: %w[DRAGNET_0052 DRAGNET_0059] do
+        context 'when the FilesVerifier fails', requirements: %w[SRS_DRAGNET_0052 SRS_DRAGNET_0059] do
           let(:failed_verification_result) do
             instance_double(
               Dragnet::VerificationResult,
@@ -245,7 +245,7 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
           it_behaves_like '#verify when one of the inner verifiers fails'
         end
 
-        context 'when the ChangesVerifier fails', requirements: %w[DRAGNET_0054 DRAGNET_0059] do
+        context 'when the ChangesVerifier fails', requirements: %w[SRS_DRAGNET_0054 SRS_DRAGNET_0059] do
           let(:failed_verification_result) do
             instance_double(
               Dragnet::VerificationResult,

--- a/spec/dragnet/verifiers/result_verifier_spec.rb
+++ b/spec/dragnet/verifiers/result_verifier_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dragnet::Verifiers::ResultVerifier do
   describe '#verify' do
     subject(:method_call) { result_verifier.verify }
 
-    context 'when the result is "passed"', requirements: ['DRAGNET_0016'] do
+    context 'when the result is "passed"', requirements: ['SRS_DRAGNET_0016'] do
       let(:result) { 'passed' }
       let(:passed) { true }
 
@@ -49,7 +49,7 @@ RSpec.describe Dragnet::Verifiers::ResultVerifier do
       end
     end
 
-    context 'when the result is "failed"', requirements: ['DRAGNET_0011'] do
+    context 'when the result is "failed"', requirements: ['SRS_DRAGNET_0011'] do
       let(:result) { 'failed' }
 
       let(:expected_parameters) do

--- a/spec/dragnet/verifiers/test_record_verifier_spec.rb
+++ b/spec/dragnet/verifiers/test_record_verifier_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe Dragnet::Verifiers::TestRecordVerifier do
           .with(status: :passed).and_return(passed_verification_result)
       end
 
-      it 'creates a passed VerificationResult', requirements: %w[DRAGNET_0016] do
+      it 'creates a passed VerificationResult', requirements: %w[SRS_DRAGNET_0016] do
         expect(Dragnet::VerificationResult).to receive(:new).with(status: :passed)
         method_call
       end
 
-      it 'returns the passed VerificationResult', requirements: %w[DRAGNET_0016] do
+      it 'returns the passed VerificationResult', requirements: %w[SRS_DRAGNET_0016] do
         expect(method_call).to eq(passed_verification_result)
       end
     end
@@ -213,7 +213,8 @@ RSpec.describe Dragnet::Verifiers::TestRecordVerifier do
         method_call
       end
 
-      it 'uses the ReposVerifier to verify the changes to the listed repositories', requirements: %w[DRAGNET_0050] do
+      it 'uses the ReposVerifier to verify the changes to the listed repositories',
+         requirements: %w[SRS_DRAGNET_0050] do
         expect(Dragnet::Verifiers::ReposVerifier).to receive(:new)
           .with(test_record: test_record, multi_repository: repository)
 

--- a/spec/integration/dragnet/cli/master_spec.rb
+++ b/spec/integration/dragnet/cli/master_spec.rb
@@ -4,7 +4,7 @@ require 'dragnet/cli/master'
 require 'shared/cli_master'
 
 RSpec.describe Dragnet::CLI::Master do
-  describe '--version', requirements: %w[DRAGNET_0017 DRAGNET_0026] do
+  describe '--version', requirements: %w[SRS_DRAGNET_0017 SRS_DRAGNET_0026] do
     subject(:output) { `#{base_command}` }
 
     let(:base_command) { 'bundle exec exe/dragnet --version' }

--- a/spec/integration/dragnet/exporters/html_exporter_spec.rb
+++ b/spec/integration/dragnet/exporters/html_exporter_spec.rb
@@ -37,7 +37,7 @@ RSpec.shared_context 'with a test repository for Dragnet::Exporters::HTMLExporte
   end
 end
 
-RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['DRAGNET_0022'] do
+RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_0022'] do
   subject(:output) { html_exporter.export }
 
   let(:html_exporter) do
@@ -249,7 +249,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['DRAGNET_0022'] 
     end
   end
 
-  describe 'colors from verification results', requirements: ['DRAGNET_0024'] do
+  describe 'colors from verification results', requirements: ['SRS_DRAGNET_0024'] do
     include_context 'with a mocked template for Dragnet::Exporters::HTMLExporter'
 
     let(:test_record) do
@@ -502,7 +502,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['DRAGNET_0022'] 
       expect(output).not_to include(temp_dir.to_s)
     end
 
-    describe 'list of MTR files', requirements: ['DRAGNET_0023'] do
+    describe 'list of MTR files', requirements: ['SRS_DRAGNET_0023'] do
       it 'lists the MTR files that were successfully loaded' do
         expect(output).to include('source/tests/manual/safe_e2e.yaml')
           .and include('source/tests/manual/io_vectors.yaml')
@@ -515,7 +515,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['DRAGNET_0022'] 
       end
     end
 
-    it 'lists the reasons for the failure/skipping of the test records', requirements: ['DRAGNET_0025'] do
+    it 'lists the reasons for the failure/skipping of the test records', requirements: ['SRS_DRAGNET_0025'] do
       expect(output).to include('changes detected in the repository f13dbbc..6e94407')
         .and include("result key has the value 'failed'")
     end

--- a/spec/integration/dragnet/exporters/json_exporter_spec.rb
+++ b/spec/integration/dragnet/exporters/json_exporter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
         expect(method_call).to be_a(String)
       end
 
-      it 'produces parseable JSON', requirements: %w[DRAGNET_0060] do
+      it 'produces parseable JSON', requirements: %w[SRS_DRAGNET_0060] do
         expect { re_parsed_json }.not_to raise_error
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
         end
       end
 
-      context 'when errors are present', requirements: %w[DRAGNET_0063] do
+      context 'when errors are present', requirements: %w[SRS_DRAGNET_0063] do
         include_context 'with errors'
 
         it_behaves_like '#export when no TestRecords are given'
@@ -224,11 +224,11 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
           re_parsed_json.map { |object| object['verification_result'] }
         end
 
-        it 'produces an array with an element for each Test Record object', requirements: %w[DRAGNET_0061] do
+        it 'produces an array with an element for each Test Record object', requirements: %w[SRS_DRAGNET_0061] do
           expect(re_parsed_json.size).to eq(test_records.size)
         end
 
-        it 'produces an array of Hashes', requirements: %w[DRAGNET_0061] do
+        it 'produces an array of Hashes', requirements: %w[SRS_DRAGNET_0061] do
           expect(re_parsed_json).to all(be_a(Hash))
         end
 
@@ -236,31 +236,31 @@ RSpec.describe Dragnet::Exporters::JSONExporter do
           expect(method_call).to eq(expected_json)
         end
 
-        it 'includes all the MTRs', requirements: %w[DRAGNET_0061] do
+        it 'includes all the MTRs', requirements: %w[SRS_DRAGNET_0061] do
           ids = re_parsed_json.flat_map { |object| object['id'] }
           expect(ids).to eq(%w[2de4fadc0e37faff 02c3a37bb344f280 77ac686a8f4b46dd])
         end
 
-        it 'includes the Verification Result for each MTR', requirements: %w[DRAGNET_0062] do
+        it 'includes the Verification Result for each MTR', requirements: %w[SRS_DRAGNET_0062] do
           expect(verification_results).to all(be_a(Hash))
         end
 
-        it 'includes the start_at attribute in each Verification Result', requirements: %w[DRAGNET_0078] do
+        it 'includes the start_at attribute in each Verification Result', requirements: %w[SRS_DRAGNET_0078] do
           expect(verification_results).to all(have_key('started_at'))
         end
 
-        it 'includes the finished_at attribute in each Verification Result', requirements: %w[DRAGNET_0078] do
+        it 'includes the finished_at attribute in each Verification Result', requirements: %w[SRS_DRAGNET_0078] do
           expect(verification_results).to all(have_key('finished_at'))
         end
 
-        it 'includes the runtime attribute in each Verification Result', requirements: %w[DRAGNET_0078] do
+        it 'includes the runtime attribute in each Verification Result', requirements: %w[SRS_DRAGNET_0078] do
           expect(verification_results).to all(have_key('runtime'))
         end
       end
 
       it_behaves_like '#export when test records are given'
 
-      context 'when errors are present', requirements: %w[DRAGNET_0063] do
+      context 'when errors are present', requirements: %w[SRS_DRAGNET_0063] do
         include_context 'with errors'
 
         it_behaves_like '#export when test records are given'


### PR DESCRIPTION
Requirement IDs were updated in #10 (8bd2af0), however their links in the spec files were left unchanged. This commit fixes that issue.