### PR TITLE
[ELITERT-1221] Fix crashes with GitHub hosted repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Fixed
+- Dragnet no longer crashes when generating an HTML report for a repository
+  hosted on Github.
+
 ## [5.3.0] - 2024-12-03
 
 ### Added

--- a/lib/dragnet/repository.rb
+++ b/lib/dragnet/repository.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'git/url'
 
 require_relative 'base_repository'
 
@@ -36,7 +37,7 @@ module Dragnet
     #
     # @return [String] The URI path of the repository
     def remote_uri_path
-      URI.parse(git.remotes.first.url).path
+      Git::URL.parse(git.remotes.first.url).path
     end
 
     # @return [FalseClass] It always returns false

--- a/spec/dragnet/repository_spec.rb
+++ b/spec/dragnet/repository_spec.rb
@@ -84,10 +84,12 @@ RSpec.describe Dragnet::Repository do
   describe '#remote_uri_path' do
     subject(:method_call) { repository.remote_uri_path }
 
+    let(:remote_url) { 'ssh://focal.fossa@gerrit.local:29418/projects/central/bsw' }
+
     let(:remote) do
       instance_double(
         Git::Remote,
-        url: 'ssh://focal.fossa@gerrit.int.esrlabs.com:29418/projects/central/bsw'
+        url: remote_url
       )
     end
 
@@ -109,8 +111,50 @@ RSpec.describe Dragnet::Repository do
       method_call
     end
 
-    it "returns only the path of the remote's URL" do
-      expect(method_call).to eq('/projects/central/bsw')
+    context 'when the URL is a standard SSH url' do
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('/projects/central/bsw')
+      end
+    end
+
+    context 'when the URL is a Git URL' do
+      let(:remote_url) { 'git://git@git.local/esrlabs/dox.git' }
+
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('/esrlabs/dox.git')
+      end
+    end
+
+    context 'when the URL is a GitHub URL' do
+      let(:remote_url) { 'git@github.com:esrlabs/dox.git' }
+
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('/esrlabs/dox.git')
+      end
+    end
+
+    context 'when the URL is an HTTPS URL' do
+      let(:remote_url) { 'https://github.com/esrlabs/dox.git' }
+
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('/esrlabs/dox.git')
+      end
+    end
+
+    context 'when the URL is a file URL' do
+      let(:remote_url) { '~/Projects/esrlabs/dox' }
+
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('~/Projects/esrlabs/dox')
+      end
+    end
+
+    context 'when the URL is a JOSH URL' do
+      let(:remote_url) { 'https://focal.fossa@josh.local/bsw.git:/libs.git' }
+
+      it "returns only the path of the remote's URL" do
+        expect(method_call).to eq('/bsw.git:/libs.git')
+      end
     end
   end
 


### PR DESCRIPTION
Fixes an issue that caused Dragnet to crash when generating an HTML report for the results of an execution over a repository hosted on Github.

The reason for the crash was that Ruby's URI parser is incapable of parsing a GitHub URL, so, it was replaced by Git's `URL.parse` method, which is capable of doing it.