### PR TITLE
[RELEASE] Version 5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [5.3.1] - 2024-12-13
+
 ### Fixed
 - Dragnet no longer crashes when generating an HTML report for a repository
   hosted on Github.

--- a/lib/dragnet/version.rb
+++ b/lib/dragnet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dragnet
-  VERSION = '5.3.0'
+  VERSION = '5.3.1'
 end


### PR DESCRIPTION
### Fixed
- Dragnet no longer crashes when generating an HTML report for a repository
  hosted on Github.