### PR TITLE
[ELITERT-1219] Export requirements with the docs

### DIFF
--- a/.github/workflows/sphinx-doc.yml
+++ b/.github/workflows/sphinx-doc.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Generate YARD documentation
       run: |
         bundler exec yard doc . --exclude vendor/ -o documentation/build/html/yard
+    - name: Export Requirements
+      run: |
+        bundler exec dim_to_rst req/config.yml documentation/source/requirements
     - name: Install pandoc
       run: |
         sudo apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ end
 
 group :requirements do
   gem 'dim-toolkit', '2.1.1' # Fixed to a minor because the Gem doesn't follow semantic versioning.
+  gem 'dim_to_rst', '~> 2'
 end


### PR DESCRIPTION
Updates the Github action that generates the Sphinx documentation to also include a step to export the requirements as RST.

For this the `dim_to_rst` gem is being added to the development dependencies.