### PR TITLE
[ESRTEST-20396] Add --number-only to --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- A `--number-only` / `-n` switch to the `--version` CLI command that only
+  prints the version number.
+
 ## [5.3.1] - 2024-12-13
 
 ### Fixed

--- a/lib/dragnet/cli/master.rb
+++ b/lib/dragnet/cli/master.rb
@@ -30,9 +30,16 @@ module Dragnet
       map %w[--version -v] => :version
 
       desc '--version', 'Prints the current version of the Gem'
+      method_option :'number-only',
+                    aliases: 'n', type: :boolean,
+                    desc: 'If given, only the version number will be printed'
       def version
-        say "Dragnet #{Dragnet::VERSION}"
-        say "Copyright (c) #{Time.now.year} ESR Labs GmbH esrlabs.com"
+        if options[:'number-only']
+          say Dragnet::VERSION
+        else
+          say "Dragnet #{Dragnet::VERSION}"
+          say "Copyright (c) #{Time.now.year} ESR Labs GmbH esrlabs.com"
+        end
       end
 
       desc 'check [PATH]', 'Executes the verification procedure. '\

--- a/spec/dragnet/cli/master_spec.rb
+++ b/spec/dragnet/cli/master_spec.rb
@@ -68,14 +68,34 @@ RSpec.describe Dragnet::CLI::Master do
       expect { method_call }.to output(expected_output).to_stdout
     end
 
-    context 'when the quit options is given' do
+    shared_examples_for '#version when the quiet option is given' do
       before do
-        master.options = { quiet: true }
+        master.options = master.options.merge(quiet: true)
       end
 
       it "doesn't print anything to the output" do
         expect { method_call }.not_to output.to_stdout
       end
+    end
+
+    context 'when the --number-only option is given' do
+      before do
+        master.options = master.options.merge('number-only': true)
+      end
+
+      include_context "with the number-only CLI's --version output"
+
+      it 'prints only the version number' do
+        expect { method_call }.to output(expected_output).to_stdout
+      end
+
+      context 'when the quiet option is given' do
+        it_behaves_like '#version when the quiet option is given'
+      end
+    end
+
+    context 'when the quiet option is given' do
+      it_behaves_like '#version when the quiet option is given'
     end
   end
 

--- a/spec/integration/dragnet/cli/master_spec.rb
+++ b/spec/integration/dragnet/cli/master_spec.rb
@@ -5,24 +5,41 @@ require 'shared/cli_master'
 
 RSpec.describe Dragnet::CLI::Master do
   describe '--version', requirements: %w[SRS_DRAGNET_0017 SRS_DRAGNET_0026] do
-    subject(:output) { `#{base_command}` }
+    subject(:output) { `#{command}` }
 
-    let(:base_command) { 'bundle exec exe/dragnet --version' }
+    let(:command) { 'bundle exec exe/dragnet --version' }
 
     include_context "with the default CLI's --version output"
 
-    it 'prints the current version of the gem' do
-      expect(output).to eq(expected_output)
-    end
-
-    context 'when the -q switch is used' do
-      subject(:output) { `#{base_command} -q` }
-
+    shared_examples_for '--version when the quiet option is given' do
+      let(:command) { "#{super()} -q" }
       let(:expected_output) { '' }
 
       it 'prints nothing' do
         expect(output).to eq(expected_output)
       end
+    end
+
+    it 'prints the current version of the gem' do
+      expect(output).to eq(expected_output)
+    end
+
+    context 'when the --number-only version is given' do
+      let(:command) { "#{super()} -n" }
+
+      include_context "with the number-only CLI's --version output"
+
+      it 'prints only the version number' do
+        expect(output).to eq(expected_output)
+      end
+
+      context 'when the -q switch is used' do
+        it_behaves_like '--version when the quiet option is given'
+      end
+    end
+
+    context 'when the -q switch is used' do
+      it_behaves_like '--version when the quiet option is given'
     end
   end
 end

--- a/spec/shared/cli_master.rb
+++ b/spec/shared/cli_master.rb
@@ -8,3 +8,11 @@ RSpec.shared_context "with the default CLI's --version output" do
     TEXT
   end
 end
+
+RSpec.shared_context "with the number-only CLI's --version output" do
+  let(:expected_output) do
+    <<~TEXT
+      #{Dragnet::VERSION}
+    TEXT
+  end
+end


### PR DESCRIPTION
Adds a `--number-only` / `-n` switch to the `--version` CLI command that only prints the version number.

The main driver behind this change is to being able to collect the tool's version during execution. The output produced when the switch is active can be used directly without further parsing.