### PR TITLE
[RELEASE] Version 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [5.4.0] - 2025-04-07
+
 ### Added
 - A `--number-only` / `-n` switch to the `--version` CLI command that only
   prints the version number.

--- a/lib/dragnet/version.rb
+++ b/lib/dragnet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dragnet
-  VERSION = '5.3.1'
+  VERSION = '5.4.0'
 end


### PR DESCRIPTION
In this release:

### Added
- A `--number-only` / `-n` switch to the `--version` CLI command that only
  prints the version number.