### PR TITLE
[BUGFIX] Fix a crash when all the inner verifiers in a ReposVerifier pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Fixed
+- A bug that caused Dragnet to crash during a multi-repo mode verification in
+  which all the repositories listed in the MTR passed the verification.
+
 ## [5.4.0] - 2025-04-07
 
 ### Added

--- a/lib/dragnet/verifiers/repos_verifier.rb
+++ b/lib/dragnet/verifiers/repos_verifier.rb
@@ -34,6 +34,8 @@ module Dragnet
 
           return verification_result if verification_result
         end
+
+        nil
       rescue Dragnet::Errors::NotARepositoryError => e
         Dragnet::VerificationResult.new(status: :failed, reason: e.message)
       end

--- a/spec/dragnet/verifiers/repos_verifier_spec.rb
+++ b/spec/dragnet/verifiers/repos_verifier_spec.rb
@@ -217,6 +217,12 @@ RSpec.describe Dragnet::Verifiers::ReposVerifier do
         end
       end
 
+      context 'when none of the inner verifiers fail' do
+        it 'returns nil' do
+          expect(method_call).to be_nil
+        end
+      end
+
       describe 'Inner verifier failures' do
         shared_examples_for '#verify when one of the inner verifiers fails' do
           before do


### PR DESCRIPTION
Fixes a crash that occurred in multi-repo mode when all the repos listed in an MTR pass all the verifiers.

In this case the array of `Repo` objects was being returned by `ReposVerifier#verify`. This return value was bubbling up all the way up to `Verifier#verify_mtr`, which caused a `NoMethodError` to be raised because the method was expecting a `VerificationResult` object, not the array of `Repo` objects.