### PR TITLE
[RELEASE] Version 5.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [5.4.2] - 2025-05-22
+
 ### Fixed
 - Dragnet no longer crashes when an invalid / non-existing SHA1 is used in a MTR.
 

--- a/lib/dragnet/version.rb
+++ b/lib/dragnet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dragnet
-  VERSION = '5.4.1'
+  VERSION = '5.4.2'
 end


### PR DESCRIPTION
In this release:

### Fixed
- Dragnet no longer crashes when an invalid / non-existing SHA1 is used in a MTR.