### PR TITLE
[ELITERT-1275] Update git dependency from '~> 1.8' to '~> 3'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 ## [Unreleased]
 
 ### Changed
+- ! Updated the `git` gem dependency from `~> 1.8` to `~> 3`
 - ! Set the minimum Ruby version requirement to `3.1.0`
 
 ## [5.4.2] - 2025-05-22

--- a/dragnet.gemspec
+++ b/dragnet.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '~> 7'
   spec.add_runtime_dependency 'colorize', '~> 0.8'
-  spec.add_runtime_dependency 'git', '~> 1.8'
+  spec.add_runtime_dependency 'git', '~> 3'
   spec.add_runtime_dependency 'thor', '~> 1.1'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
The update is needed because git 3.0.0 includes a fix for the `#branch` method which prevents it from crashing when used with a repository in a detached HEAD state.