### PR TITLE
[RELEASE] Version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [6.0.0] - 2025-09-23
+
 ### Changed
 - ! Updated the `git` gem dependency from `~> 1.8` to `~> 3`
 - ! Set the minimum Ruby version requirement to `3.1.0`

--- a/lib/dragnet/version.rb
+++ b/lib/dragnet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dragnet
-  VERSION = '5.4.2'
+  VERSION = '6.0.0'
 end


### PR DESCRIPTION
In this release:

### Changed
- ! Updated the `git` gem dependency from `~> 1.8` to `~> 3`
- ! Set the minimum Ruby version requirement to `3.1.0`