### PR TITLE
Remove alert from HTML report

### DIFF
--- a/lib/dragnet/exporters/templates/template.html.erb
+++ b/lib/dragnet/exporters/templates/template.html.erb
@@ -81,16 +81,6 @@
             <div class="page-wrapper">
                 <div class="page-body">
                     <div class="container-xl">
-                        <div class="alert alert-warning alert-dismissible" role="alert">
-                            <div class="d-flex">
-                                <div>
-                                    <h4 class="alert-title">Not a customer report</h4>
-                                    <div class="text-muted">Please be aware that this report should not be shared with external stakeholders. Exports for customers can be provided by other tools.</div>
-                                </div>
-                            </div>
-                            <a class="btn-close" data-bs-dismiss="alert" aria-label="close"></a>
-                        </div>
-
                         <div class="row row-deck row-cards mb-3">
                             <div class="col-sm-12">
                                 <div class="card">


### PR DESCRIPTION
The given alert covers a specific use case and is not relevant when using
Dragnet as a tool in general.
