### PR TITLE
[ESRTEST-28279] Fix SRS_DRAGNET_0074 and SRS_DRAGNET_0080

### DIFF
--- a/req/exporter.dim
+++ b/req/exporter.dim
@@ -161,6 +161,7 @@ SRS_DRAGNET_0080:
                    The 'description' text shall be sanitized **BEFORE**
                    rendering it as Markdown to prevent XSS in the generated HTML
                    report.
+  test_setups:     off_target
   tags:            covered, tested
 
 SRS_DRAGNET_0081:

--- a/req/verifier.dim
+++ b/req/verifier.dim
@@ -136,6 +136,7 @@ SRS_DRAGNET_0074:
   text:            |
                    The result of the verification shall include information on
                    when the verification was executed and how much time it took.
+  tags:            covered, tested
   test_setups:     none
   status:          valid
   refs:            SRS_DRAGNET_0075, SRS_DRAGNET_0076, SRS_DRAGNET_0077


### PR DESCRIPTION
Fix two small issues with the requirements `SRS_DRAGNET_0074` and `SRS_DRAGNET_0080`:

* `SRS_DRAGNET_0074`: Was missing the tags `'covered'` and `'tested'`
* `SRS_DRAGNET_0080`: Was missing the `test_setups` attribute

Because of the issues above the traceability was showing these requirements as not being fully derived and not covered by tests, respectively.