### PR TITLE
[ELITERT-1366] Allow the "Test Results" table in the HTML report to be sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- The "Test Results" table in the HTML report can now be sorted by clicking on
+  the table's headers.
+
 ## [6.0.0] - 2025-09-23
 
 ### Changed

--- a/lib/dragnet/exporters/html_exporter.rb
+++ b/lib/dragnet/exporters/html_exporter.rb
@@ -91,7 +91,7 @@ module Dragnet
           color = test_record.reviewed? ? 'green' : 'red'
           review_status = test_record.review_status.capitalize
         else
-          color = 'gray'
+          color = 'muted'
           review_status = '(unknown)'
         end
 
@@ -143,7 +143,7 @@ module Dragnet
       # @return [String] The HTML code to produce a badge with the given color
       #   and text.
       def badge_html(color, text)
-        "<span class=\"badge bg-#{color}\">#{text}</span>"
+        "<span class=\"badge bg-#{color} text-#{color}-fg\">#{text}</span>"
       end
 
       # Converts the ID (+String+) or IDs (+Array<String>+) of a +TestRecord+

--- a/lib/dragnet/exporters/templates/template.html.erb
+++ b/lib/dragnet/exporters/templates/template.html.erb
@@ -2,9 +2,9 @@
     <head>
         <meta charset="UTF-8" />
         <title>Dragnet Report for <%= repository.multi? ? "Multiple Repositories" : shorten_sha1(repository.head.sha) %></title>
-        <script src="https://unpkg.com/@tabler/core@1.0.0-beta2/dist/js/tabler.min.js"></script>
+        <script src="https://unpkg.com/@tabler/core@1.0.0/dist/js/tabler.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@tabler/core@1.0.0-beta2/dist/css/tabler.min.css">
+        <link rel="stylesheet" href="https://unpkg.com/@tabler/core@1.0.0/dist/css/tabler.min.css">
     </head>
     <body class="antialiased"> <!-- theme-dark -->
         <div class="wrapper">
@@ -284,7 +284,7 @@
 
                                                     <tr>
                                                         <td><%= relative_to_repo(error[:file]) %></td>
-                                                        <td><span class="badge bg-red">Failed</span></td>
+                                                        <td><span class="badge bg-red text-red-fg">Failed</span></td>
                                                         <td><%= error[:message] %><br><%= error[:exception].message %></td>
                                                     </tr>
 
@@ -294,7 +294,7 @@
 
                                                     <tr>
                                                         <td><%= relative_to_repo(test_record.source_file) %></td>
-                                                        <td><span class="badge bg-green">Successfully Loaded</span></td>
+                                                        <td><span class="badge bg-green text-green-fg">Successfully Loaded</span></td>
                                                         <td>-</td>
                                                     </tr>
 

--- a/lib/dragnet/exporters/templates/template.html.erb
+++ b/lib/dragnet/exporters/templates/template.html.erb
@@ -506,12 +506,14 @@
             </div>
         </div>
         <script type="text/javascript">
-          elements = document.getElementsByClassName('md-description')
+            document.addEventListener("DOMContentLoaded", function () {
+                const elements = document.getElementsByClassName('md-description')
 
-          for(let element of elements) {
-              const source = element.innerText
-              element.innerHTML = marked.parse(source)
-          }
+                for (let element of elements) {
+                    const source = element.innerText
+                    element.innerHTML = marked.parse(source)
+                }
+            })
         </script>
     </body>
 </html>

--- a/lib/dragnet/exporters/templates/template.html.erb
+++ b/lib/dragnet/exporters/templates/template.html.erb
@@ -3,6 +3,7 @@
         <meta charset="UTF-8" />
         <title>Dragnet Report for <%= repository.multi? ? "Multiple Repositories" : shorten_sha1(repository.head.sha) %></title>
         <script src="https://unpkg.com/@tabler/core@1.0.0/dist/js/tabler.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@tabler/core@1.0.0/dist/css/tabler.min.css">
     </head>
@@ -314,28 +315,40 @@
                                         <div class="card-header">
                                             <h3 class="card-title">Overview</h3>
                                         </div>
-                                        <div class="table-responsive">
+                                        <div id="test-results-table" class="table-responsive">
                                             <table class="table table-vcenter table-hover">
                                                 <thead>
                                                     <tr>
-                                                        <th>#</th>
-                                                        <th>Requirement ID</th>
-                                                        <th>SHA1</th>
-                                                        <th>Files</th>
-                                                        <th>Review Status</th>
-                                                        <th>Test Result</th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-number">#</button>
+                                                        </th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-requirement-id">Requirement ID</button>
+                                                        </th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-sha1">SHA1</button>
+                                                        </th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-files">Files</button>
+                                                        </th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-review-status">Review Status</button>
+                                                        </th>
+                                                        <th>
+                                                          <button class="table-sort d-flex justify-content-between" data-sort="sort-test-result">Test Result</button>
+                                                        </th>
                                                         <th>Details</th>
                                                     </tr>
                                                 </thead>
-                                                <tbody>
+                                                <tbody class="table-tbody">
 
                                                     <% test_records.each_with_index do |test_record, index| %>
 
                                                         <tr>
-                                                            <td><%= index + 1 %></td>
-                                                            <td><%= test_record_id_to_string(test_record) %></td>
-                                                            <td><%= test_record.sha1 ? shorten_sha1(test_record.sha1) : '(None)' %></td>
-                                                            <td>
+                                                            <td class="sort-number"><%= index + 1 %></td>
+                                                            <td class="sort-requirement-id"><%= test_record_id_to_string(test_record) %></td>
+                                                            <td class="sort-sha1"><%= test_record.sha1 ? shorten_sha1(test_record.sha1) : '(None)' %></td>
+                                                            <td class="sort-files">
 
                                                                 <% if test_record.files&.any? %>
 
@@ -348,8 +361,8 @@
                                                                 <% end %>
 
                                                             </td>
-                                                            <td><%= review_status_badge(test_record) %></td>
-                                                            <td><%= verification_result_badge(test_record.verification_result) %></td>
+                                                            <td class="sort-review-status"><%= review_status_badge(test_record) %></td>
+                                                            <td class="sort-test-result"><%= verification_result_badge(test_record.verification_result) %></td>
                                                             <td><a href="#test-record-<%= index %>">
                                                                 <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevrons-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                                                                     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -507,6 +520,18 @@
         </div>
         <script type="text/javascript">
             document.addEventListener("DOMContentLoaded", function () {
+                let headers = []
+
+                document.querySelectorAll('#test-results-table thead button').forEach(function(headerButton){
+                    headers.push(headerButton.dataset.sort)
+                })
+
+                new List("test-results-table", {
+                    sortClass: "table-sort",
+                    listClass: "table-tbody",
+                    valueNames: headers,
+                })
+
                 const elements = document.getElementsByClassName('md-description')
 
                 for (let element of elements) {

--- a/spec/integration/dragnet/exporters/html_exporter_spec.rb
+++ b/spec/integration/dragnet/exporters/html_exporter_spec.rb
@@ -517,23 +517,21 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
     end
 
     let(:marked_invocation_fragment) do
-      <<~JAVASCRIPT.indent(14)
+      <<~JAVASCRIPT.indent(20)
         const source = element.innerText
         element.innerHTML = marked.parse(source)
       JAVASCRIPT
     end
 
     let(:markdown_transform_script) do
-      <<-HTML
-        <script type="text/javascript">
-          elements = document.getElementsByClassName('md-description')
+      <<~JAVASCRIPT.indent(16)
+        const elements = document.getElementsByClassName('md-description')
 
-          for(let element of elements) {
-              const source = element.innerText
-              element.innerHTML = marked.parse(source)
-          }
-        </script>
-      HTML
+        for (let element of elements) {
+            const source = element.innerText
+            element.innerHTML = marked.parse(source)
+        }
+      JAVASCRIPT
     end
 
     let(:expected_dd_tag) do

--- a/spec/integration/dragnet/exporters/html_exporter_spec.rb
+++ b/spec/integration/dragnet/exporters/html_exporter_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
       let(:expected_output) do
         <<~HTML
-          <span class=\"badge bg-gray\">(unknown)</span>
+          <span class=\"badge bg-muted text-muted-fg\">(unknown)</span>
         HTML
       end
 
@@ -224,7 +224,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
       let(:expected_output) do
         <<~HTML
-          <span class=\"badge bg-green\">Reviewed</span>
+          <span class=\"badge bg-green text-green-fg\">Reviewed</span>
         HTML
       end
 
@@ -242,7 +242,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
       let(:expected_output) do
         <<~HTML
-          <span class=\"badge bg-red\">Inreview</span>
+          <span class=\"badge bg-red text-red-fg\">Inreview</span>
         HTML
       end
 
@@ -273,7 +273,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
         let(:expected_output) do
           <<~HTML
-            <span class=\"badge bg-green\">Passed</span>
+            <span class=\"badge bg-green text-green-fg\">Passed</span>
           HTML
         end
 
@@ -285,7 +285,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
         let(:expected_output) do
           <<~HTML
-            <span class=\"badge bg-yellow\">Skipped</span>
+            <span class=\"badge bg-yellow text-yellow-fg\">Skipped</span>
           HTML
         end
 
@@ -297,7 +297,7 @@ RSpec.describe Dragnet::Exporters::HTMLExporter, requirements: ['SRS_DRAGNET_002
 
         let(:expected_output) do
           <<~HTML
-            <span class=\"badge bg-red\">Failed</span>
+            <span class=\"badge bg-red text-red-fg\">Failed</span>
           HTML
         end
 


### PR DESCRIPTION
Allow the "Test Results" table in the HTML template to be sorted by clicking on the table's headers.

To be able to do this change the following additional changes were made:

* Adds a `DOMContentLoaded` event listener and encases the script inside of it. This is better than just having the script directly inside the `<script>` tag because it ensures that all the DOM elements are loaded and ready before the script starts to run.
* Updates the [Tabler](https://tabler.io/admin-template) template from `1.0.0-beta2` to `1.0.0`. This is needed because the `beta2` version is missing the styling for the headers of the sortable tables.