### PR TITLE
Update RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,11 @@ AllCops:
   Exclude:
     - vendor/**/*
     - spec/spec_helper.rb
+Layout/LineLength:
+  Max: 120
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
-Metrics/LineLength:
-  Max: 120
 Metrics/MethodLength:
   Max: 15
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
The RuboCop configuration has been invalid for a while. The `Metrics/LineLength` cop is now called `Layout/LineLength`. With this issue in the configuration RuboCop just refuses to run.

This commit fixes the issue allowing RuboCop to run again.