### PR TITLE
[RELEASE] Version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-06-19
+
 ### Changed
 - ! Increased the minimum Ruby version requirement to `3.2.2`
 

--- a/lib/dragnet/version.rb
+++ b/lib/dragnet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dragnet
-  VERSION = '6.1.0'
+  VERSION = '7.0.0'
 end


### PR DESCRIPTION
In this release:

### Changed
- ! Increased the minimum Ruby version requirement to `3.2.2`